### PR TITLE
NullPointerException fix

### DIFF
--- a/src/main/java/com/soasta/jenkins/TestCompositionRunner.java
+++ b/src/main/java/com/soasta/jenkins/TestCompositionRunner.java
@@ -97,9 +97,9 @@ public class TestCompositionRunner extends AbstractSCommandBuilder {
         EnvVars envs = build.getEnvironment(listener);
         String[] compositions = envs.expand(this.composition).split("[\r\n]+");
         String additionalOptionsExpanded = additionalOptions == null ? 
-          null : envs.expand(additionalOptions);
+            null : envs.expand(additionalOptions);
         String[] options = additionalOptionsExpanded == null ?
-          null : new QuotedStringTokenizer(additionalOptionsExpanded).toArray();
+            null : new QuotedStringTokenizer(additionalOptionsExpanded).toArray();
 
         for (String composition : compositions) {
             ArgumentListBuilder args = getSCommandArgs(build, listener);
@@ -124,9 +124,8 @@ public class TestCompositionRunner extends AbstractSCommandBuilder {
             xml.getParent().mkdirs();
 
             // Add the additional options to the composition if there are any.
-            if (options != null)
-            {
-              args.add(options);
+            if (options != null) {
+                args.add(options);
             }
             
             // Run it!


### PR DESCRIPTION
The following fix will make sure that the additional options, when null, do not cause an NPE exception and is not added along with the other arguments, if there are no options to pass along.
