### PR TITLE
Improve handling of invalid URLs.  Previously, saving an invalid URL wou...

### DIFF
--- a/src/main/java/com/soasta/jenkins/AbstractSCommandBuilder.java
+++ b/src/main/java/com/soasta/jenkins/AbstractSCommandBuilder.java
@@ -5,6 +5,7 @@
 package com.soasta.jenkins;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.regex.Pattern;
 
 import jenkins.model.Jenkins;
@@ -64,7 +65,7 @@ public abstract class AbstractSCommandBuilder extends Builder {
           // Jenkins is configured to use a proxy server.
 
           // Extract the destination CloudTest host.
-          String host = s.getUrl().getHost();
+          String host = new URL(s.getUrl()).getHost();
 
           // Check if the proxy applies for this destination host.
           // This code is more or less copied from ProxyConfiguration.createProxy() :-(.

--- a/src/main/java/com/soasta/jenkins/MakeAppTouchTestableInstaller.java
+++ b/src/main/java/com/soasta/jenkins/MakeAppTouchTestableInstaller.java
@@ -26,7 +26,7 @@ public class MakeAppTouchTestableInstaller extends CommonInstaller {
     @Override
     public Installable getInstallable() throws IOException {
         Installable i = new Installable();
-        i.url = new URL(getServer().getUrl(), getInstallerType().getInstallerDownloadPath()).toExternalForm();
+        i.url = getServer().getUrl() + getInstallerType().getInstallerDownloadPath();
         i.id = id;
         i.name = getBuildNumber().toString();
         return i;

--- a/src/main/java/com/soasta/jenkins/SCommandInstaller.java
+++ b/src/main/java/com/soasta/jenkins/SCommandInstaller.java
@@ -26,7 +26,7 @@ public class SCommandInstaller extends CommonInstaller {
     @Override
     public Installable getInstallable() throws IOException {
         Installable i = new Installable();
-        i.url = new URL(getServer().getUrl(), getInstallerType().getInstallerDownloadPath()).toExternalForm();
+        i.url = getServer().getUrl() + getInstallerType().getInstallerDownloadPath();
         i.id = id;
         i.name = getBuildNumber().toString();
         return i;

--- a/src/main/java/com/soasta/jenkins/iOSAppInstallerInstaller.java
+++ b/src/main/java/com/soasta/jenkins/iOSAppInstallerInstaller.java
@@ -28,7 +28,7 @@ public class iOSAppInstallerInstaller extends CommonInstaller {
     @Override
     public Installable getInstallable() throws IOException {
         Installable i = new Installable();
-        i.url = new URL(getServer().getUrl(), getInstallerType().getInstallerDownloadPath()).toExternalForm();
+        i.url = getServer().getUrl() + getInstallerType().getInstallerDownloadPath();
         i.id = id;
         i.name = getBuildNumber().toString();
         return i;

--- a/src/main/java/com/soasta/jenkins/iOSSimulatorLauncher.java
+++ b/src/main/java/com/soasta/jenkins/iOSSimulatorLauncher.java
@@ -97,7 +97,7 @@ public class iOSSimulatorLauncher extends Builder {
         // The simulator will automatically open this URL
         // in Mobile Safari.
         String agentURL;
-        String cloudTestServerUrl = server.getUrl().toString();
+        String cloudTestServerUrl = server.getUrl();
         
         if (cloudTestServerUrl.endsWith("/"))
             agentURL = cloudTestServerUrl + "touchtest";


### PR DESCRIPTION
...ld cause a 500 Internal Server Error, because we assumed we could parse it.  Now we don't assume that the input is valid.  Also adds inline validation to the Configure Jenkins UI.
