### PR TITLE
Adding Mixed Content Error Message

### DIFF
--- a/src/main/java/com/soasta/jenkins/JunitResultPublisher.java
+++ b/src/main/java/com/soasta/jenkins/JunitResultPublisher.java
@@ -75,6 +75,12 @@ public class JunitResultPublisher extends TestDataPublisher
       // Get the local path of the JUnit XML file (may be on a slave node).
       String fileName = sr.getFile();
 
+      if (fileName == null || fileName.length() <= 0)
+      {
+        listener.error("The selected JUnit XML file does not exist.  Skipping.");
+        continue;
+      }
+      
       // Get local path of the build's workspace.
       String workspacePath = build.getWorkspace().getRemote();
 

--- a/src/main/resources/com/soasta/jenkins/JunitResultAction/summary.jelly
+++ b/src/main/resources/com/soasta/jenkins/JunitResultAction/summary.jelly
@@ -71,8 +71,19 @@
                                             <br/>
                                             <br/>
 
+                        <j:choose>
+                          <j:when test="${it.Url}">
                             <iframe id="ifr" src="${it.Url}/Central?initResultsTab=${it.ResultID}" style="display:none" width="100%" height="1000"></iframe>
-
+                          </j:when>
+                          
+                          <j:otherwise>
+                            The CloudTest dashboard may not load properly, because the CloudTest URL uses HTTPS and the Jenkins URL uses HTTP. You can correct this by either:
+                            <br/>
+                            <lu>browsing to Jenkins via HTTPS (if available)</lu>
+                            <br/>
+                            <lu>changing the CloudTest URL in the Jenkins configuration to use HTTP instead of HTTPS</lu>
+                          </j:otherwise>
+                        </j:choose>
             </j:if>
             
         </j:otherwise>


### PR DESCRIPTION
Adding an error message for not being able to display mixed content when iframe and Jenkins have different URL schemes.