### PR TITLE
Empty Fields in CloudTest Server

### DIFF
--- a/src/main/java/com/soasta/jenkins/AbstractSCommandBuilder.java
+++ b/src/main/java/com/soasta/jenkins/AbstractSCommandBuilder.java
@@ -56,8 +56,10 @@ public abstract class AbstractSCommandBuilder extends Builder {
       ArgumentListBuilder args = new ArgumentListBuilder();
       args.add(scommand)
           .add("url=" + s.getUrl())
-          .add("username="+s.getUsername())
-          .addMasked("password=" + s.getPassword());
+          .add("username="+s.getUsername());
+          
+      if (s.getPassword() != null)
+          args.addMasked("password=" + s.getPassword());
       
       ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
 

--- a/src/main/java/com/soasta/jenkins/CloudTestServer.java
+++ b/src/main/java/com/soasta/jenkins/CloudTestServer.java
@@ -79,8 +79,14 @@ public class CloudTestServer extends AbstractDescribableImpl<CloudTestServer> {
             this.url = url;
         }
 
-        this.username = username;
-        this.password = password;
+        if (username == null || username.isEmpty()) {
+          this.username = "";
+          this.password = null;
+        }
+        else {
+          this.username = username;
+          this.password = password;
+        }
 
         // If the ID is empty, auto-generate one.
         if (id == null || id.isEmpty()) {
@@ -98,6 +104,10 @@ public class CloudTestServer extends AbstractDescribableImpl<CloudTestServer> {
 
         // If the name is empty, default to URL + user name.
         if (name == null || name.isEmpty()) {
+          if (this.url == null) {
+            this.name = "";
+          }
+          else {
             this.name = url + " (" + username + ")";
 
             // This is probably a configuration created using
@@ -105,6 +115,7 @@ public class CloudTestServer extends AbstractDescribableImpl<CloudTestServer> {
             // existed).  Set a flag so we can write the new
             // values after initialization (see DescriptorImpl).
             generatedIdOrName = true;
+          }
         }
         else {
             this.name = name;
@@ -158,7 +169,12 @@ public class CloudTestServer extends AbstractDescribableImpl<CloudTestServer> {
 
         PostMethod post = new PostMethod(url + "Login");
         post.addParameter("userName",getUsername());
-        post.addParameter("password",getPassword().getPlainText());
+        
+        if (getPassword() != null) {
+          post.addParameter("password",getPassword().getPlainText());
+        } else {
+          post.addParameter("password","");
+        }
 
         hc.executeMethod(post);
 

--- a/src/main/java/com/soasta/jenkins/CloudTestServer.java
+++ b/src/main/java/com/soasta/jenkins/CloudTestServer.java
@@ -81,10 +81,15 @@ public class CloudTestServer extends AbstractDescribableImpl<CloudTestServer> {
 
         if (username == null || username.isEmpty()) {
           this.username = "";
-          this.password = null;
         }
         else {
           this.username = username;
+        }
+        
+        if (password == null || password.getPlainText() == null || password.getPlainText().isEmpty()) {
+          this.password = null;
+        }
+        else {
           this.password = password;
         }
 

--- a/src/main/java/com/soasta/jenkins/MakeAppTouchTestable.java
+++ b/src/main/java/com/soasta/jenkins/MakeAppTouchTestable.java
@@ -149,8 +149,10 @@ public class MakeAppTouchTestable extends Builder {
         args.add("-jar").add(path.child("MakeAppTouchTestable.jar"))
             .add("-overwriteapp")
             .add("-url").add(s.getUrl())
-            .add("-username",s.getUsername())
-            .add("-password").addMasked(s.getPassword().getPlainText());
+            .add("-username",s.getUsername());
+            
+        if (s.getPassword() != null)
+            args.add("-password").addMasked(s.getPassword().getPlainText());
 
         args.add(inputType.getInputType(), envs.expand(projectFile));
         

--- a/src/main/java/com/soasta/jenkins/TestCompositionRunner.java
+++ b/src/main/java/com/soasta/jenkins/TestCompositionRunner.java
@@ -262,8 +262,10 @@ public class TestCompositionRunner extends AbstractSCommandBuilder {
             args.add(install(s))
                 .add("list", "type=composition")
                 .add("url=" + s.getUrl())
-                .add("username=" + s.getUsername())
-                .addMasked("password=" + s.getPassword());
+                .add("username=" + s.getUsername());
+            
+            if (s.getPassword() != null)
+                args.addMasked("password=" + s.getPassword());
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             int exit = new LocalLauncher(TaskListener.NULL).launch().cmds(args).stdout(out).join();


### PR DESCRIPTION
If a user forgets to input any information in the CloudTest Server, those fields will remain blank for the user to fill out.  Passwords, from now on, will also only be passed in the arguments if one is supplied.