### PR TITLE
Fix apitoken handling:

### DIFF
--- a/src/main/java/com/soasta/jenkins/MakeAppTouchTestable.java
+++ b/src/main/java/com/soasta/jenkins/MakeAppTouchTestable.java
@@ -147,15 +147,15 @@ public class MakeAppTouchTestable extends Builder {
             .add(new QuotedStringTokenizer(envs.expand(javaOptions)).toArray())
             .add("-jar")
             .add(path.child("MakeAppTouchTestable.jar"))
-            .add("-overwriteapp");
+            .add("-overwriteapp")
+            .add("-url").add(s.getUrl());
 
-        if(s.getApitoken() != null) {
+        if(s.getApitoken() != null && !s.getApitoken().isEmpty()) {
             args.add("-apitoken")
                 .add(s.getApitoken()); 
         }
         else {
-            args.add("-url").add(s.getUrl())
-                .add("-username",s.getUsername()); 
+            args.add("-username",s.getUsername()); 
             
             if (s.getPassword() != null) {
                 args.add("-password")


### PR DESCRIPTION
Fix apitoken handling:
1. If apitoken is empty string, ignore it
2. Grab url first before detecting apitoken